### PR TITLE
BENCH-1317 BENCH-1301 prevent access to technology with no content

### DIFF
--- a/src/components/Radar/Radar.tsx
+++ b/src/components/Radar/Radar.tsx
@@ -12,6 +12,7 @@ import StyledGroup from "../RadarStyledComponents/StyledGroup";
 import { Wrapper, StyledNav } from "./styles/";
 import { RadarTooltip } from "../RadarStyledComponents/StyledTooltip";
 import { getRowLength } from "../../helpers/helpers";
+import techContent from "../../data/content/index";
 
 const labels = [
   "DevOps",
@@ -55,6 +56,13 @@ const Radar: FC<Props> = ({
     useContext<RadarContextType>(RadarContext);
   const [hovered, setHovered] = useState("DevOps");
 
+  const technologyHasNoContent = (technologyName: string) =>
+    techContent.find(
+      (item) =>
+        item.technology === technologyName &&
+        (item.content === undefined || item.content.length == 0)
+    );
+
   const handleClick = (categoryName: string) => {
     setCategory(categoryName);
     history.push(`/category/${categoryName.replace(/\s/g, "-")}`.toLowerCase());
@@ -63,6 +71,8 @@ const Radar: FC<Props> = ({
   const handleClickIcon = (categoryName: string, technologyName: string) => {
     setCategory(categoryName);
     setTechnology(technologyName);
+
+    if (technologyHasNoContent(technologyName)) return;
 
     history.push(
       `/technology/${categoryName}/${technologyName}`

--- a/src/components/Radar/Radar.tsx
+++ b/src/components/Radar/Radar.tsx
@@ -359,7 +359,12 @@ const Radar: FC<Props> = ({
                         placement="top"
                         arrow
                       >
-                        <g className={`techIcon-${dataPoint.name}`}>
+                        <g
+                          className={`techIcon-${dataPoint.name} ${
+                            technologyHasNoContent(dataPoint.name) &&
+                            "no-content"
+                          }`}
+                        >
                           {/* background circle for icons */}
                           <circle
                             key={`preferred-${dataPoint.name}-${idx}`}

--- a/src/components/Radar/_tests_/Radar.test.tsx
+++ b/src/components/Radar/_tests_/Radar.test.tsx
@@ -17,6 +17,48 @@ describe("Radar", () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it("should click Consul icon on Radar and check that url has not changed", () => {
+    const technologyClassNameWithNoContent = "techIcon-Consul";
+    const { container } = render(
+      <Router>
+        <Radar
+          scalingClicked={true}
+          skilledClicked={true}
+          preferredClicked={true}
+        />
+      </Router>
+    );
+    const g = container.querySelectorAll("g");
+    g.forEach((x) => {
+      if (x.outerHTML.includes(technologyClassNameWithNoContent)) {
+        fireEvent.click(x);
+      }
+    });
+    expect(window.location.href).toBe("http://localhost/");
+  });
+
+  it("should click React icon on Radar and check that url is /technology/frontend/react", () => {
+    const technologyClassNameWithContent = "techIcon-React";
+    const { container } = render(
+      <Router>
+        <Radar
+          scalingClicked={true}
+          skilledClicked={true}
+          preferredClicked={true}
+        />
+      </Router>
+    );
+    const g = container.querySelectorAll("g");
+    g.forEach((x) => {
+      if (x.outerHTML.includes(technologyClassNameWithContent)) {
+        fireEvent.click(x);
+      }
+    });
+    expect(window.location.href).toBe(
+      "http://localhost/technology/frontend/react"
+    );
+  });
+
   it("should click DevOps on Radar and check that url is /category/devops", () => {
     render(
       <Router>

--- a/src/components/Radar/_tests_/__snapshots__/Radar.test.tsx.snap
+++ b/src/components/Radar/_tests_/__snapshots__/Radar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Radar should render Radar component 1`] = `
 <div
-  class="styles__Wrapper-sc-2tg2y4-0 fGwopy"
+  class="styles__Wrapper-sc-2tg2y4-0 gFBxwn"
 >
   <svg
     style="overflow: visible;"

--- a/src/components/Radar/styles/index.tsx
+++ b/src/components/Radar/styles/index.tsx
@@ -13,6 +13,9 @@ export const Wrapper = styled.div`
   @media screen and (max-width: 1000px) {
     display: none;
   }
+  g {
+    cursor: pointer;
+  }
 `;
 
 export const StyledNav = styled.g`

--- a/src/components/Radar/styles/index.tsx
+++ b/src/components/Radar/styles/index.tsx
@@ -13,8 +13,13 @@ export const Wrapper = styled.div`
   @media screen and (max-width: 1000px) {
     display: none;
   }
+
   g {
     cursor: pointer;
+  }
+
+  g.no-content {
+    cursor: default;
   }
 `;
 


### PR DESCRIPTION
## Ticket

[*https://ilabs-capco.atlassian.net/browse/BENCH-1317*](https://ilabs-capco.atlassian.net/browse/BENCH-1317)
[*https://ilabs-capco.atlassian.net/browse/BENCH-1301*](https://ilabs-capco.atlassian.net/browse/BENCH-1301)

## Description

- If a technology has no content
  - clicking it will not move to the content page
  - it will not have a cursor pointer
- Added new unit tests for clicking icons on the radar

Steps to replicate/text:
- Go to PR link: https://d595884e.tech-radar-dtc.pages.dev/home
- Hover over react
  - expect cursor to be a pointer and can click to the content page
- Hover over Angular
  - expect cursor to be default and you cannot click to the content page

## WIP

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

*PRs that should not be reviewed should be marked as a WIP.

- [ ] This PR is currently a work-in-progress.
- [x] This PR is ready for review.

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] My PR meets the acceptance criteria as outlined by my ticket.
- [ ] I updated/added relevant documentation and comments (docs start with `///` and comments with `//`).
- [ ] Static analysis (e.g. Snyk) does not report any problems on my PR.

## Screenshots

*Screenshots can be added here.*
