### PR TITLE
fix category and project links to go to specific category page

### DIFF
--- a/src/components/BreadCrumb/_test_/__snapshots__/index.test.tsx.snap
+++ b/src/components/BreadCrumb/_test_/__snapshots__/index.test.tsx.snap
@@ -8,15 +8,6 @@ exports[`BreadCrumb should render StyledButton component 1`] = `
 >
   <ol
     class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"
-  >
-    <li
-      class="MuiBreadcrumbs-li"
-    >
-      <p
-        class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-        style="color: grey; font-size: 12px;"
-      />
-    </li>
-  </ol>
+  />
 </nav>
 `;

--- a/src/components/BreadCrumb/index.tsx
+++ b/src/components/BreadCrumb/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react";
+import { FC } from "react";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 import Typography from "@mui/material/Typography";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
@@ -11,6 +11,7 @@ const BreadcrumbComponent: FC<RouteComponentProps> = ({
 }) => {
   const pathnames = pathname
     .replaceAll("technology", "category")
+    .replaceAll("projects", "category")
     .split("/")
     .filter((x) => x);
 
@@ -24,7 +25,7 @@ const BreadcrumbComponent: FC<RouteComponentProps> = ({
         cursor: "pointer",
       }}
     >
-      {pathnames.length > 0 ? (
+      {pathnames.length > 0 && (
         <BreadcrumbStyles>
           <Link
             color="#fff"
@@ -37,15 +38,13 @@ const BreadcrumbComponent: FC<RouteComponentProps> = ({
             TECH RADAR
           </Link>
         </BreadcrumbStyles>
-      ) : (
-        <Typography style={{ color: "grey", fontSize: "12px" }}></Typography>
       )}
       {pathnames.map((name, index) => {
         const routeTo = `/${pathnames.slice(0, index++).join("/")}`;
         const isLast = index === pathnames.length;
         const Name = name.toUpperCase();
 
-        const HandleClick = () => {
+        const HandleClick = (event: any) => {
           if (
             routeTo.indexOf(
               "mobile" ||
@@ -58,6 +57,10 @@ const BreadcrumbComponent: FC<RouteComponentProps> = ({
                 "devops"
             )
           ) {
+            if (event.target.innerText === "CATEGORY") {
+              history.push(`/category/${pathnames[index]}`);
+              return;
+            }
             history.push(`/${pathnames.slice(0, index++).join("/")}`);
           }
         };


### PR DESCRIPTION
## Ticket

[https://ilabs-capco.atlassian.net/browse/BENCH-1374](https://ilabs-capco.atlassian.net/browse/BENCH-1374)

## Description

Fixed bug where category breadcrumb always goes to devops category page. Now it will go to the corresponding category page. Also fixed it for the projects pages.

## WIP

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

*PRs that should not be reviewed should be marked as a WIP.

- [ ] This PR is currently a work-in-progress.
- [x] This PR is ready for review.

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] My PR meets the acceptance criteria as outlined by my ticket.
- [ ] I updated/added relevant documentation and comments (docs start with `///` and comments with `//`).
- [ ] Static analysis (e.g. Snyk) does not report any problems on my PR.

## Screenshots

*Screenshots can be added here.*
