### PR TITLE
BENCH-1457 improve alignment for mobile view

### DIFF
--- a/src/components/BackLink/styles/index.tsx
+++ b/src/components/BackLink/styles/index.tsx
@@ -5,6 +5,7 @@ const StyledBackLink = styled(Link)`
   font-size: 17px;
   display: block;
   color: inherit;
+  margin-left: -10px;
   img {
     margin-left: 10px !important;
   }

--- a/src/containers/ContentPage/ContentPage.tsx
+++ b/src/containers/ContentPage/ContentPage.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
+import Grid from "@material-ui/core/Grid";
 import {
   RadarContextType,
   RadarContext,
@@ -19,6 +20,7 @@ import {
   ContentBody,
   Title,
   Divider,
+  StyledWrapper,
 } from "./styles/";
 import ContentNavButton from "../../components/ComponentNavButton/ContentNavButton";
 import {
@@ -125,7 +127,18 @@ const CategoryPage = () => {
       />
       {content && (
         <ContentWrapper>
-          <BackLink category={category} />
+          <Grid container justify="space-between">
+            <Grid item>
+              <BackLink category={category} />
+            </Grid>
+            <Grid item>
+              <StyledWrapper showMobileLink>
+                <ClientProjectLink
+                  onClick={() => handleClick(category, technology)}
+                />
+              </StyledWrapper>
+            </Grid>
+          </Grid>
           <div className="content-head">
             <div>
               <Title className={`title-${technology}`}>{technology}</Title>
@@ -143,9 +156,11 @@ const CategoryPage = () => {
               </a>
             </div>
             {(ossProjectCount !== 0 || clientProjectCount !== 0) && (
-              <ClientProjectLink
-                onClick={() => handleClick(category, technology)}
-              />
+              <StyledWrapper>
+                <ClientProjectLink
+                  onClick={() => handleClick(category, technology)}
+                />
+              </StyledWrapper>
             )}
           </div>
           <ContentBody>

--- a/src/containers/ContentPage/styles/index.tsx
+++ b/src/containers/ContentPage/styles/index.tsx
@@ -46,6 +46,9 @@ export const ContentWrapper = styled.div`
       width: 50px;
       height: 50px;
     }
+    .content-head {
+      padding: 30px 0;
+    }
   }
   .content-head {
     display: flex;
@@ -96,4 +99,16 @@ export const Divider = styled.hr`
     rgba(255, 255, 255, 0.75),
     rgba(255, 255, 255, 0)
   );
+`;
+
+export const StyledWrapper = styled.div<{ showMobileLink?: boolean }>`
+  ${({ showMobileLink }) =>
+    showMobileLink
+      ? `
+    @media screen and (min-width: 1000px) {display: none;};
+    > a {
+      font-size: 17px;
+    }
+    `
+      : `@media screen and (max-width: 1000px) {display: none;}`}
 `;


### PR DESCRIPTION
## Ticket

[*BENCH-1457*](https://ilabs-capco.atlassian.net/browse/BENCH-1457)

## Description

On a content page such as "React", the "View Projects" link on the top right should be smaller and inline with the "Back to" link on a mobile/small screen view

## WIP

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

*PRs that should not be reviewed should be marked as a WIP.

- [ ] This PR is currently a work-in-progress.
- [x] This PR is ready for review.

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] My PR meets the acceptance criteria as outlined by my ticket.
- [ ] I updated/added relevant documentation and comments (docs start with `///` and comments with `//`).
- [ ] Static analysis (e.g. Snyk) does not report any problems on my PR.

## Screenshots

*Screenshots can be added here.*
